### PR TITLE
Backport 1.14.4 to 1.12.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
-cct_version=1.86.2
+cct_version=1.89.2
 mod_version=0.1.2
-mc_version=1.14.4
-forge_version=28.2.0
-mappings_version=20190719-1.14.3
+mc_version=1.12.2
+forge_version=14.23.5.2854
+mappings_version=20180724-1.12

--- a/src/main/java/com/sci/cclj/CCLuaJIT.java
+++ b/src/main/java/com/sci/cclj/CCLuaJIT.java
@@ -1,44 +1,17 @@
 package com.sci.cclj;
 
-import net.minecraftforge.fml.ModContainer;
-import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 
 import java.util.Optional;
 
-@Mod(CCLuaJIT.MOD_ID)
+@Mod(modid = CCLuaJIT.MOD_ID, name = CCLuaJIT.MOD_NAME, version = CCLuaJIT.MOD_VERSION)
 public final class CCLuaJIT {
     public static final String MOD_ID = "ccluajit";
+    public static final String MOD_NAME = "CCLuaJIT";
+    public static final String CCT_VERSION = "1.89.2";
+    public static final String MOD_VERSION = "0.1.2";
+    public static final String MC_VERSION = "1.12.2";
 
     public CCLuaJIT() {
-    }
-
-    // NOTE TODO: Can this be done better? Probably, but yknow. gdasjlgw
-
-    public static String getCCLJVersion() {
-        final Optional<? extends ModContainer> cclj = ModList.get().getModContainerById(MOD_ID);
-        if(cclj.isPresent()) {
-            final ModContainer c = cclj.get();
-            return c.getModInfo().getVersion().toString();
-        }
-        throw new RuntimeException("Failed to retrieve ModContainer for '" + MOD_ID + "'");
-    }
-
-    public static String getMinecraftVersion() {
-        final Optional<? extends ModContainer> oc = ModList.get().getModContainerById("minecraft");
-        if (oc.isPresent()) {
-            final ModContainer c = oc.get();
-            return c.getModInfo().getVersion().toString();
-        }
-        throw new RuntimeException("Failed to retrieve ModContainer for 'minecraft'");
-    }
-
-    public static String getComputerCraftVersion() {
-        final Optional<? extends ModContainer> oc = ModList.get().getModContainerById("computercraft");
-        if (oc.isPresent()) {
-            final ModContainer c = oc.get();
-            return c.getModInfo().getVersion().toString();
-        }
-        throw new RuntimeException("Failed to retrieve ModContainer for 'computercraft'");
     }
 }

--- a/src/main/java/com/sci/cclj/computer/LuaJITMachine.java
+++ b/src/main/java/com/sci/cclj/computer/LuaJITMachine.java
@@ -114,9 +114,9 @@ public final class LuaJITMachine implements ILuaMachine, ILuaContext {
         this.timeout = timeout;
 
         if (!this.initMachine(
-                CCLuaJIT.getCCLJVersion(),
-                CCLuaJIT.getComputerCraftVersion(),
-                CCLuaJIT.getMinecraftVersion(),
+                CCLuaJIT.MOD_VERSION,
+                CCLuaJIT.CCT_VERSION,
+                CCLuaJIT.MC_VERSION,
                 computer.getAPIEnvironment().getComputerEnvironment().getHostString(),
                 ComputerCraft.default_computer_settings,
                 ThreadLocalRandom.current().nextLong())) {


### PR DESCRIPTION
I've successfully used your CCLuaJIT project to run a gameboy emulator at full speed in ComputerCraft: https://github.com/zeta0134/LuaGB/issues/35#issuecomment-689300431

It works perfectly, I really hope you'll keep working on it to bring this project to release quality. 👍 

As a personal request I'd like to see an MC 1.12.2 version as well since many modpacks are still on that version right now. I'm contributing my hacky backport in this PR which I've tested on my personal server.